### PR TITLE
修复newNodePool初始化方法，在tickerUpdatePool运行前添加任务失败

### DIFF
--- a/node_pool.go
+++ b/node_pool.go
@@ -48,6 +48,7 @@ func newNodePool(serverName string, driver driver.Driver, dcron *Dcron) *NodePoo
 	nodePool.opts = option
 
 	nodePool.initPool()
+	nodePool.updatePool()
 
 	go nodePool.tickerUpdatePool()
 


### PR DESCRIPTION
修复newNodePool初始化方法，因tickerUpdatePool执行有时延，在第一次updatePool前，添加任务会失败